### PR TITLE
Better printing to show unstored values

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["ITensor developers <support@itensor.org> and contributors"]
 version = "0.2.3"
 
 [deps]
+Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 DerivableInterfaces = "6c5e35bf-e59e-4898-b73c-732dcc4ba65f"
 Dictionaries = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
@@ -11,6 +12,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MapBroadcast = "ebd9b9da-f48d-417c-9660-449667d60261"
 
 [compat]
+Accessors = "0.1.41"
 Aqua = "0.8.9"
 ArrayLayouts = "1.11.0"
 DerivableInterfaces = "0.3.7"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SparseArraysBase"
 uuid = "0d5efcca-f356-4864-8770-e1ed8d78f208"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/abstractsparsearray.jl
+++ b/src/abstractsparsearray.jl
@@ -24,3 +24,28 @@ using LinearAlgebra: LinearAlgebra
 # which is where matrix multiplication and factorizations
 # should go.
 @derive AnyAbstractSparseArray AbstractArrayOps
+const MIMEtextplain = MIME"text/plain"
+@derive (T=AnyAbstractSparseArray,) begin
+  Base.show(::IO, ::MIMEtextplain, ::T)
+end
+
+# Wraps a sparse array but replaces the unstored values.
+# This is used in printing in order to customize printing
+# of zero/unstored values.
+struct ReplacedUnstoredSparseArray{T,N,F,Parent<:AbstractArray{T,N}} <:
+       AbstractSparseArray{T,N}
+  parent::Parent
+  getunstoredindex::F
+end
+Base.parent(a::ReplacedUnstoredSparseArray) = a.parent
+Base.size(a::ReplacedUnstoredSparseArray) = size(parent(a))
+function isstored(a::ReplacedUnstoredSparseArray, I::Int...)
+  return isstored(parent(a), I...)
+end
+function getstoredindex(a::ReplacedUnstoredSparseArray, I::Int...)
+  return getstoredindex(parent(a), I...)
+end
+function getunstoredindex(a::ReplacedUnstoredSparseArray, I::Int...)
+  return a.getunstoredindex(a, I...)
+end
+@derive ReplacedUnstoredSparseArray AbstractArrayOps

--- a/src/abstractsparsearrayinterface.jl
+++ b/src/abstractsparsearrayinterface.jl
@@ -14,6 +14,10 @@ function storedlength end
 function storedpairs end
 function storedvalues end
 
+# Replace the function for accessing
+# unstored values.
+function set_getunstoredindex end
+
 # Generic functionality for converting to a
 # dense array, trying to preserve information
 # about the array (such as which device it is on).
@@ -375,4 +379,27 @@ struct SparseLayout <: AbstractSparseLayout end
 
 @interface ::AbstractSparseArrayInterface function ArrayLayouts.MemoryLayout(type::Type)
   return SparseLayout()
+end
+
+# Like `Char` but prints without quotes.
+struct UnquotedChar <: AbstractChar
+  char::Char
+end
+Base.show(io::IO, c::UnquotedChar) = print(io, c.char)
+Base.show(io::IO, ::MIME"text/plain", c::UnquotedChar) = show(io, c)
+
+function show_getunstoredindex(a::AbstractArray, I::Int...)
+  return UnquotedChar('⋅')
+end
+
+@interface ::AbstractSparseArrayInterface function Base.show(
+  io::IO, mime::MIME"text/plain", a::AbstractArray
+)
+  summary(io, a)
+  isempty(a) && return nothing
+  print(io, ":")
+  println(io)
+  a′ = ReplacedUnstoredSparseArray(a, show_getunstoredindex)
+  Base.print_array(io, a′)
+  return nothing
 end

--- a/src/sparsearraydok.jl
+++ b/src/sparsearraydok.jl
@@ -1,3 +1,4 @@
+using Accessors: @set
 using Dictionaries: Dictionary, IndexError, set!
 
 function default_getunstoredindex(a::AbstractArray, I::Int...)
@@ -8,6 +9,11 @@ struct SparseArrayDOK{T,N,F} <: AbstractSparseArray{T,N}
   storage::Dictionary{CartesianIndex{N},T}
   size::NTuple{N,Int}
   getunstoredindex::F
+end
+
+function set_getunstoredindex(a::SparseArrayDOK, f)
+  @set a.getunstoredindex = f
+  return a
 end
 
 using DerivableInterfaces: DerivableInterfaces

--- a/test/basics/test_sparsearraydok.jl
+++ b/test/basics/test_sparsearraydok.jl
@@ -168,4 +168,11 @@ arrayts = (Array,)
   @test storedlength(b) == 2
   @test b[1, 2] == 12
   @test b[4, 3] == 21
+
+  # Printing
+  # Not testing other element types since they change the
+  # spacing so it isn't easy to make the test general.
+  a = SparseArrayDOK{Float64}(2, 2)
+  a[1, 2] = 12
+  @test sprint(show, "text/plain", a) == "$(summary(a)):\n ⋅  $(eltype(a)(12))\n ⋅    ⋅"
 end


### PR DESCRIPTION
Before this PR, unstored values were just printed as normal zero values, while with this PR we have:
```julia
julia> using SparseArraysBase: SparseArrayDOK

julia> a = SparseArrayDOK{Float64}(2, 2)
2×2 SparseArrayDOK{Float64, 2, typeof(SparseArraysBase.default_getunstoredindex)}:
 ⋅  ⋅
 ⋅  ⋅

julia> a[1, 2] = 3
3

julia> a
2×2 SparseArrayDOK{Float64, 2, typeof(SparseArraysBase.default_getunstoredindex)}:
 ⋅  3.0
 ⋅   ⋅
```
similar to the printing in [SparseArrays.jl](https://github.com/JuliaSparse/SparseArrays.jl).