### PR TITLE
Backport a 1.10 implementation for `LinearAlgebra.diagind`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SparseArraysBase"
 uuid = "0d5efcca-f356-4864-8770-e1ed8d78f208"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.2.9"
+version = "0.2.10"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -164,8 +164,18 @@ end
 
 using LinearAlgebra: Diagonal
 @interface ::AbstractArrayInterface storedvalues(D::Diagonal) = LinearAlgebra.diag(D)
+
+# compat with LTS:
+@static if VERSION ≥ v"1.11"
+  _diagind = LinearAlgebra.diagind
+else
+  function _diagind(x::Diagonal, ::IndexCartesian)
+    return view(CartesianIndices(x), LinearAlgebra.diagind(x))
+  end
+end
 @interface ::AbstractArrayInterface eachstoredindex(D::Diagonal) =
-  LinearAlgebra.diagind(D, IndexCartesian())
+  _diagind(D, IndexCartesian())
+
 @interface ::AbstractArrayInterface isstored(D::Diagonal, i::Int, j::Int) =
   i == j && Base.checkbounds(Bool, D, i, j)
 @interface ::AbstractArrayInterface function getstoredindex(D::Diagonal, i::Int, j::Int)

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -162,7 +162,7 @@ for type in (:Adjoint, :PermutedDimsArray, :ReshapedArray, :SubArray, :Transpose
   end
 end
 
-using LinearAlgebra: Diagonal
+using LinearAlgebra: LinearAlgebra, Diagonal
 @interface ::AbstractArrayInterface storedvalues(D::Diagonal) = LinearAlgebra.diag(D)
 
 # compat with LTS:


### PR DESCRIPTION
This provides a simple backwards fix of the LTS implementation of `eachstoredindex(::Diagonal)`.

See also https://github.com/ITensor/BlockSparseArrays.jl/issues/32