### PR TITLE
Simplify show implementation

### DIFF
--- a/src/abstractsparsearray.jl
+++ b/src/abstractsparsearray.jl
@@ -25,34 +25,11 @@ using LinearAlgebra: LinearAlgebra
 # should go.
 @derive AnyAbstractSparseArray AbstractArrayOps
 
-# This type alias is a temporary workaround since `@derive`
-# doesn't parse the `@MIME_str` macro properly at the moment.
-const MIMEtextplain = MIME"text/plain"
-@derive (T=AnyAbstractSparseArray,) begin
-  Base.show(::IO, ::MIMEtextplain, ::T)
+function Base.replace_in_print_matrix(
+  A::AnyAbstractSparseArray{<:Any,2}, i::Integer, j::Integer, s::AbstractString
+)
+  return isstored(A, CartesianIndex(i, j)) ? s : Base.replace_with_centered_mark(s)
 end
-
-# Wraps a sparse array but replaces the unstored values.
-# This is used in printing in order to customize printing
-# of zero/unstored values.
-struct ReplacedUnstoredSparseArray{T,N,F,Parent<:AbstractArray{T,N}} <:
-       AbstractSparseArray{T,N}
-  parent::Parent
-  getunstoredindex::F
-end
-Base.parent(a::ReplacedUnstoredSparseArray) = a.parent
-Base.size(a::ReplacedUnstoredSparseArray) = size(parent(a))
-function isstored(a::ReplacedUnstoredSparseArray, I::Int...)
-  return isstored(parent(a), I...)
-end
-function getstoredindex(a::ReplacedUnstoredSparseArray, I::Int...)
-  return getstoredindex(parent(a), I...)
-end
-function getunstoredindex(a::ReplacedUnstoredSparseArray, I::Int...)
-  return a.getunstoredindex(a, I...)
-end
-eachstoredindex(a::ReplacedUnstoredSparseArray) = eachstoredindex(parent(a))
-@derive ReplacedUnstoredSparseArray AbstractArrayOps
 
 # Special-purpose constructors
 # ----------------------------

--- a/src/abstractsparsearrayinterface.jl
+++ b/src/abstractsparsearrayinterface.jl
@@ -384,26 +384,3 @@ struct SparseLayout <: AbstractSparseLayout end
 @interface ::AbstractSparseArrayInterface function ArrayLayouts.MemoryLayout(type::Type)
   return SparseLayout()
 end
-
-# Like `Char` but prints without quotes.
-struct UnquotedChar <: AbstractChar
-  char::Char
-end
-Base.show(io::IO, c::UnquotedChar) = print(io, c.char)
-Base.show(io::IO, ::MIME"text/plain", c::UnquotedChar) = show(io, c)
-
-function getunstoredindex_show(a::AbstractArray, I::Int...)
-  return UnquotedChar('⋅')
-end
-
-@interface ::AbstractSparseArrayInterface function Base.show(
-  io::IO, mime::MIME"text/plain", a::AbstractArray
-)
-  summary(io, a)
-  isempty(a) && return nothing
-  print(io, ":")
-  println(io)
-  a′ = ReplacedUnstoredSparseArray(a, getunstoredindex_show)
-  Base.print_array(io, a′)
-  return nothing
-end

--- a/test/test_sparsearraydok.jl
+++ b/test/test_sparsearraydok.jl
@@ -175,7 +175,8 @@ arrayts = (Array,)
     # spacing so it isn't easy to make the test general.
     a = SparseArrayDOK{elt}(undef, 2, 2)
     a[1, 2] = 12
-    @test sprint(show, "text/plain", a) == "$(summary(a)):\n ⋅  $(eltype(a)(12))\n ⋅    ⋅"
+    @test sprint(show, "text/plain", a) ==
+      "$(summary(a)):\n  ⋅   $(eltype(a)(12))\n  ⋅     ⋅ "
   end
 
   # Regression test for:


### PR DESCRIPTION
This PR simplifies a bit of the code used for defining show by leveraging the built-in Base functionality of replacing values for printing.
This shouldn't change the functionality, although it does change a bit of the exact alignment properties.
In particular, here, the zero-value print is used to determine things like alignment, and only afterwards is this replaced with a centered dot, while I think the previous implementation first replaced the entries with dots, and only then computed alignments.