### PR TITLE
Define `isstored` for `SubArray`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SparseArraysBase"
 uuid = "0d5efcca-f356-4864-8770-e1ed8d78f208"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/abstractsparsearrayinterface.jl
+++ b/src/abstractsparsearrayinterface.jl
@@ -102,6 +102,10 @@ end
   SparseArraysBase.storedvalues(::T)
 end
 
+function isstored(a::SubArray, I::Int...)
+  return isstored(parent(a), Base.reindex(parentindices(a), I)...)
+end
+
 # TODO: Add `ndims` type parameter, like `Base.Broadcast.AbstractArrayStyle`.
 # TODO: This isn't used to define interface functions right now.
 # Currently, `@interface` expects an instance, probably it should take a

--- a/src/abstractsparsearrayinterface.jl
+++ b/src/abstractsparsearrayinterface.jl
@@ -54,6 +54,10 @@ end
   return error("Not implemented.")
 end
 
+@interface ::AbstractArrayInterface function isstored(a::SubArray, I::Int...)
+  return isstored(parent(a), Base.reindex(parentindices(a), I)...)
+end
+
 # TODO: Use `Base.to_indices`?
 isstored(a::AbstractArray, I::CartesianIndex) = isstored(a, Tuple(I)...)
 # TODO: Use `Base.to_indices`?
@@ -102,8 +106,8 @@ end
   SparseArraysBase.storedvalues(::T)
 end
 
-function isstored(a::SubArray, I::Int...)
-  return isstored(parent(a), Base.reindex(parentindices(a), I)...)
+@derive (T=SubArray,) begin
+  SparseArraysBase.isstored(::T, ::Int...)
 end
 
 # TODO: Add `ndims` type parameter, like `Base.Broadcast.AbstractArrayStyle`.

--- a/src/abstractsparsearrayinterface.jl
+++ b/src/abstractsparsearrayinterface.jl
@@ -54,10 +54,6 @@ end
   return error("Not implemented.")
 end
 
-@interface ::AbstractArrayInterface function isstored(a::SubArray, I::Int...)
-  return isstored(parent(a), Base.reindex(parentindices(a), I)...)
-end
-
 # TODO: Use `Base.to_indices`?
 isstored(a::AbstractArray, I::CartesianIndex) = isstored(a, Tuple(I)...)
 # TODO: Use `Base.to_indices`?
@@ -104,10 +100,6 @@ end
   SparseArraysBase.storedlength(::T)
   SparseArraysBase.storedpairs(::T)
   SparseArraysBase.storedvalues(::T)
-end
-
-@derive (T=SubArray,) begin
-  SparseArraysBase.isstored(::T, ::Int...)
 end
 
 # TODO: Add `ndims` type parameter, like `Base.Broadcast.AbstractArrayStyle`.

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -106,6 +106,10 @@ function storedparentvalues(a::SubArray)
   return StoredValues(parent(a), collect(eachstoredparentindex(a)))
 end
 
+@interface ::AbstractArrayInterface function isstored(a::SubArray, I::Int...)
+  return isstored(parent(a), index_to_parentindex(a, I...)...)
+end
+
 using LinearAlgebra: Transpose
 function parentindex_to_index(a::Transpose, I::CartesianIndex{2})
   return cartesianindex_reverse(I)

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -11,7 +11,7 @@ using SparseArraysBase:
   storedlength,
   storedpairs,
   storedvalues
-using Test: @test, @testset
+using Test: @test, @test_throws, @testset
 
 elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
 arrayts = (Array, JLArray)
@@ -41,6 +41,15 @@ arrayts = (Array, JLArray)
   @allowscalar for I in eachindex(IndexCartesian(), a)
     @test getstoredindex(a, I) == a[I]
     @test iszero(getunstoredindex(a, I))
+  end
+
+  n = 2
+  a = @view dev(randn(elt, n, n))[1:2, 1]
+  @test storedlength(a) == length(a)
+  for indexstyle in (IndexLinear(), IndexCartesian())
+    for I in eachindex(indexstyle, a)
+      @test isstored(a, I)
+    end
   end
 
   a = dev(randn(elt, n, n))

--- a/test/test_sparsearraydok.jl
+++ b/test/test_sparsearraydok.jl
@@ -50,6 +50,33 @@ arrayts = (Array,)
   @test b == [0 24; 0 0]
   @test storedlength(b) == 1
 
+  # isstored
+  a = SparseArrayDOK{elt}(undef, 4, 4)
+  a[2, 3] = 23
+  for I in CartesianIndices(a)
+    if I == CartesianIndex(2, 3)
+      @test isstored(a, I)
+      @test isstored(a, Tuple(I)...)
+    else
+      @test !isstored(a, I)
+      @test !isstored(a, Tuple(I)...)
+    end
+  end
+
+  # isstored SubArray
+  a′ = SparseArrayDOK{elt}(undef, 4, 4)
+  a′[2, 3] = 23
+  a = @view a′[2:3, 2:3]
+  for I in CartesianIndices(a)
+    if I == CartesianIndex(1, 2)
+      @test isstored(a, I)
+      @test isstored(a, Tuple(I)...)
+    else
+      @test !isstored(a, I)
+      @test !isstored(a, Tuple(I)...)
+    end
+  end
+
   a = SparseArrayDOK{elt}(undef, 3, 3, 3)
   a[1, 2, 3] = 123
   b = permutedims(a, (2, 3, 1))


### PR DESCRIPTION
This generalizes a definition originally made in https://github.com/ITensor/BlockSparseArrays.jl/pull/74, with the goal of fixing https://github.com/ITensor/BlockSparseArrays.jl/issues/73.

@lkdvos ideally this code would handle things like linear indexing but that system is being rewritten in https://github.com/ITensor/SparseArraysBase.jl/pull/39 so for now I'm just following the style of how other `isstored` functions are defined.