### PR TITLE
Fix `isstored` with trailing singletons, vector show

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SparseArraysBase"
 uuid = "0d5efcca-f356-4864-8770-e1ed8d78f208"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/abstractsparsearray.jl
+++ b/src/abstractsparsearray.jl
@@ -28,9 +28,9 @@ using LinearAlgebra: LinearAlgebra
 @derive AnyAbstractSparseArray AbstractArrayOps
 
 function Base.replace_in_print_matrix(
-  A::AnyAbstractSparseArray{<:Any,2}, i::Integer, j::Integer, s::AbstractString
+  a::AnyAbstractSparseVecOrMat, i::Integer, j::Integer, s::AbstractString
 )
-  return isstored(A, CartesianIndex(i, j)) ? s : Base.replace_with_centered_mark(s)
+  return isstored(a, i, j) ? s : Base.replace_with_centered_mark(s)
 end
 
 # Special-purpose constructors

--- a/src/abstractsparsearrayinterface.jl
+++ b/src/abstractsparsearrayinterface.jl
@@ -34,7 +34,17 @@ end
 
 # Minimal interface for `SparseArrayInterface`.
 # Fallbacks for dense/non-sparse arrays.
-@interface ::AbstractArrayInterface isstored(a::AbstractArray, I::Int...) = true
+@interface ::AbstractArrayInterface function isstored(
+  a::AbstractArray{<:Any,N}, I::Vararg{Int,N}
+) where {N}
+  @boundscheck checkbounds(a, I...)
+  return true
+end
+@interface ::AbstractArrayInterface function isstored(a::AbstractArray, I::Int...)
+  @boundscheck checkbounds(a, I...)
+  I′ = ntuple(i -> I[i], ndims(a))
+  return isstored(a, I′...)
+end
 @interface ::AbstractArrayInterface eachstoredindex(a::AbstractArray) = eachindex(a)
 @interface ::AbstractArrayInterface getstoredindex(a::AbstractArray, I::Int...) =
   getindex(a, I...)

--- a/src/sparsearraydok.jl
+++ b/src/sparsearraydok.jl
@@ -73,7 +73,7 @@ storage(a::SparseArrayDOK) = a.storage
 Base.size(a::SparseArrayDOK) = a.size
 
 storedvalues(a::SparseArrayDOK) = values(storage(a))
-function isstored(a::SparseArrayDOK, I::Int...)
+function isstored(a::SparseArrayDOK{<:Any,N}, I::Vararg{Int,N}) where {N}
   return CartesianIndex(I) in keys(storage(a))
 end
 function eachstoredindex(a::SparseArrayDOK)

--- a/src/sparsearraydok.jl
+++ b/src/sparsearraydok.jl
@@ -73,8 +73,8 @@ storage(a::SparseArrayDOK) = a.storage
 Base.size(a::SparseArrayDOK) = a.size
 
 storedvalues(a::SparseArrayDOK) = values(storage(a))
-function isstored(a::SparseArrayDOK{<:Any,N}, I::Vararg{Int,N}) where {N}
-  return CartesianIndex(I) in keys(storage(a))
+function isstored(a::SparseArrayDOK, I::Int...)
+  return @interface interface(a) isstored(a, I...)
 end
 function eachstoredindex(a::SparseArrayDOK)
   return keys(storage(a))

--- a/src/sparsearraydok.jl
+++ b/src/sparsearraydok.jl
@@ -1,4 +1,5 @@
 using Accessors: @set
+using DerivableInterfaces: @interface, interface
 using Dictionaries: Dictionary, IndexError, set!
 
 function getzero(a::AbstractArray{<:Any,N}, I::Vararg{Int,N}) where {N}

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -26,6 +26,9 @@ arrayts = (Array, JLArray)
   for indexstyle in (IndexLinear(), IndexCartesian())
     for I in eachindex(indexstyle, a)
       @test isstored(a, I)
+      if indexstyle == IndexCartesian()
+        @test isstored(a, Tuple(I)..., 1)
+      end
     end
   end
   @test eachstoredindex(a) == eachindex(a)

--- a/test/test_sparsearraydok.jl
+++ b/test/test_sparsearraydok.jl
@@ -210,6 +210,10 @@ arrayts = (Array,)
     a[1, 2] = 12
     @test sprint(show, "text/plain", a) ==
       "$(summary(a)):\n  ⋅   $(eltype(a)(12))\n  ⋅     ⋅ "
+
+    a = SparseArrayDOK{elt}(undef, 2)
+    a[1] = 1
+    @test sprint(show, "text/plain", a) == "$(summary(a)):\n $(eltype(a)(1))\n  ⋅ "
   end
 
   # Regression test for:


### PR DESCRIPTION
This is a step towards addressing https://github.com/ITensor/BlockSparseArrays.jl/issues/77.

To-do:
- [x] Fix linear indexing in `isstored`.
- [x] Add tests.