### PR TITLE
Overload `DerivableInterfaces.zero!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SparseArraysBase"
 uuid = "0d5efcca-f356-4864-8770-e1ed8d78f208"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/abstractsparsearrayinterface.jl
+++ b/src/abstractsparsearrayinterface.jl
@@ -1,9 +1,6 @@
 using Base: @_propagate_inbounds_meta
-using DerivableInterfaces: DerivableInterfaces, @derive, @interface, AbstractArrayInterface
-
-# This is to bring `ArrayLayouts.zero!` into the namespace
-# since it is considered part of the sparse array interface.
-using ArrayLayouts: zero!
+using DerivableInterfaces:
+  DerivableInterfaces, @derive, @interface, AbstractArrayInterface, zero!
 
 function eachstoredindex end
 function getstoredindex end
@@ -256,13 +253,13 @@ function map_all! end
   return a_dest
 end
 
-using ArrayLayouts: ArrayLayouts, zero!
+using DerivableInterfaces: DerivableInterfaces, zero!
 
 # `zero!` isn't defined in `Base`, but it is defined in `ArrayLayouts`
 # and is useful for sparse array logic, since it can be used to empty
 # the sparse array storage.
 # We use a single function definition to minimize method ambiguities.
-@interface interface::AbstractSparseArrayInterface function ArrayLayouts.zero!(
+@interface interface::AbstractSparseArrayInterface function DerivableInterfaces.zero!(
   a::AbstractArray
 )
   # More generally, this codepath could be taking if `zero(eltype(a))`

--- a/src/sparsearraydok.jl
+++ b/src/sparsearraydok.jl
@@ -1,5 +1,5 @@
 using Accessors: @set
-using DerivableInterfaces: @interface, interface
+using DerivableInterfaces: DerivableInterfaces, @interface, interface, zero!
 using Dictionaries: Dictionary, IndexError, set!
 
 function getzero(a::AbstractArray{<:Any,N}, I::Vararg{Int,N}) where {N}
@@ -102,7 +102,11 @@ end
 # Optional, but faster than the default.
 storedpairs(a::SparseArrayDOK) = pairs(storage(a))
 
-function ArrayLayouts.zero!(a::SparseArrayDOK)
+# TODO: Also handle wrappers.
+function DerivableInterfaces.zero!(a::SparseArrayDOK)
   empty!(storage(a))
   return a
+end
+function ArrayLayouts.zero!(a::SparseArrayDOK)
+  return zero!(a)
 end


### PR DESCRIPTION
Overload `DerivableInterfaces.zero!`, reflecting changes made in https://github.com/ITensor/DerivableInterfaces.jl/pull/18.