### PR TITLE
Multiplication of size 0 sparse arrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SparseArraysBase"
 uuid = "0d5efcca-f356-4864-8770-e1ed8d78f208"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.5.6"
+version = "0.5.7"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/abstractsparsearrayinterface.jl
+++ b/src/abstractsparsearrayinterface.jl
@@ -156,6 +156,7 @@ end
 @interface interface::AbstractSparseArrayInterface function Base.map!(
   f, a_dest::AbstractArray, as::AbstractArray...
 )
+  isempty(a_dest) && return a_dest # special case to avoid trying to access empty array
   indices = if !preserves_unstored(f, a_dest, as...)
     eachindex(a_dest)
   elseif any(a -> a_dest !== a, as)

--- a/test/test_linalg.jl
+++ b/test/test_linalg.jl
@@ -29,17 +29,16 @@ const rng = StableRNG(123)
   szA = (2, 0)
   szB = (0, 2)
   szC = (szA[1], szB[2])
-  for density in 0.0:0.25:1
-    C = sparserand(rng, T, szC; density)
-    A = sparserand(rng, T, szA; density)
-    B = sparserand(rng, T, szB; density)
+  density = 0.1
+  C = sparserand(rng, T, szC; density)
+  A = sparserand(rng, T, szA; density)
+  B = sparserand(rng, T, szB; density)
 
-    check1 = mul!(Array(C), Array(A), Array(B))
-    @test mul!(copy(C), A, B) ≈ check1
+  check1 = mul!(Array(C), Array(A), Array(B))
+  @test mul!(copy(C), A, B) ≈ check1
 
-    α = rand(rng, T)
-    β = rand(rng, T)
-    check2 = mul!(Array(C), Array(A), Array(B), α, β)
-    @test mul!(copy(C), A, B, α, β) ≈ check2
-  end
+  α = rand(rng, T)
+  β = rand(rng, T)
+  check2 = mul!(Array(C), Array(A), Array(B), α, β)
+  @test mul!(copy(C), A, B, α, β) ≈ check2
 end

--- a/test/test_linalg.jl
+++ b/test/test_linalg.jl
@@ -24,4 +24,22 @@ const rng = StableRNG(123)
     check2 = mul!(Array(C), Array(A), Array(B), α, β)
     @test mul!(copy(C), A, B, α, β) ≈ check2
   end
+
+  # test empty matrix
+  szA = (2, 0)
+  szB = (0, 2)
+  szC = (szA[1], szB[2])
+  for density in 0.0:0.25:1
+    C = sparserand(rng, T, szC; density)
+    A = sparserand(rng, T, szA; density)
+    B = sparserand(rng, T, szB; density)
+
+    check1 = mul!(Array(C), Array(A), Array(B))
+    @test mul!(copy(C), A, B) ≈ check1
+
+    α = rand(rng, T)
+    β = rand(rng, T)
+    check2 = mul!(Array(C), Array(A), Array(B), α, β)
+    @test mul!(copy(C), A, B, α, β) ≈ check2
+  end
 end


### PR DESCRIPTION
The current `map` interface does not handle size 0 arrays very well, since trying to figure out if something preserves zeros tries to construct a block, which is not possible since there are no blocks.
Previously this led to a boundserror, here I bypass this case completely, more or less as a temporary fix until we actually properly tackle the mapping functionality here.