### PR TITLE
Catch more cases of sparse matmul involving adjoints

### DIFF
--- a/src/abstractsparsearray.jl
+++ b/src/abstractsparsearray.jl
@@ -152,3 +152,43 @@ function sparserand!(
     A[I] = v
   end
 end
+
+# Catch some cases that aren't getting caught by the current
+# DerivableInterfaces.jl logic.
+# TODO: Make this more systematic once DerivableInterfaces.jl
+# is rewritten.
+using ArrayLayouts: ArrayLayouts, MemoryLayout
+using LinearAlgebra: LinearAlgebra, Adjoint
+function ArrayLayouts.MemoryLayout(::Type{Transpose{T,P}}) where {T,P<:AbstractSparseMatrix}
+  return MemoryLayout(P)
+end
+function ArrayLayouts.MemoryLayout(::Type{Adjoint{T,P}}) where {T,P<:AbstractSparseMatrix}
+  return MemoryLayout(P)
+end
+function LinearAlgebra.mul!(
+  dest::AbstractMatrix,
+  A::Adjoint{<:Any,<:AbstractSparseMatrix},
+  B::AbstractSparseMatrix,
+  α::Number,
+  β::Number,
+)
+  return ArrayLayouts.mul!(dest, A, B, α, β)
+end
+function LinearAlgebra.mul!(
+  dest::AbstractMatrix,
+  A::AbstractSparseMatrix,
+  B::Adjoint{<:Any,<:AbstractSparseMatrix},
+  α::Number,
+  β::Number,
+)
+  return ArrayLayouts.mul!(dest, A, B, α, β)
+end
+function LinearAlgebra.mul!(
+  dest::AbstractMatrix,
+  A::Adjoint{<:Any,<:AbstractSparseMatrix},
+  B::Adjoint{<:Any,<:AbstractSparseMatrix},
+  α::Number,
+  β::Number,
+)
+  return ArrayLayouts.mul!(dest, A, B, α, β)
+end

--- a/test/test_linalg.jl
+++ b/test/test_linalg.jl
@@ -16,13 +16,22 @@ const rng = StableRNG(123)
     A = sparserand(rng, T, szA; density)
     B = sparserand(rng, T, szB; density)
 
-    check1 = mul!(Array(C), Array(A), Array(B))
-    @test mul!(copy(C), A, B) ≈ check1
+    check = mul!(Array(C), Array(A), Array(B))
+    @test mul!(copy(C), A, B) ≈ check
+
+    check = mul!(Array(C), Array(A)', Array(B))
+    @test mul!(copy(C), A', B) ≈ check
+
+    check = mul!(Array(C), Array(A), Array(B)')
+    @test mul!(copy(C), A, B') ≈ check
+
+    check = mul!(Array(C), Array(A)', Array(B)')
+    @test mul!(copy(C), A', B') ≈ check
 
     α = rand(rng, T)
     β = rand(rng, T)
-    check2 = mul!(Array(C), Array(A), Array(B), α, β)
-    @test mul!(copy(C), A, B, α, β) ≈ check2
+    check = mul!(Array(C), Array(A), Array(B), α, β)
+    @test mul!(copy(C), A, B, α, β) ≈ check
   end
 
   # test empty matrix


### PR DESCRIPTION
This is a bit hacky, but it fixes https://github.com/ITensor/BlockSparseArrays.jl/issues/24.

It was caused by a subtle confluence of issues:
1. `blocks(A)'` where `A` is a `BlockSparseMatrix` isn't a subtype of `AnyAbstractSparseArray`, since the element type of the `Adjoint` wrapper is the `Adjoint` of the element type of `blocks(a)`, i.e. the type is `Adjoint{Adjoint{Float64,Matrix{Float64}},SparseMatrixDOK{Matrix{Float64}}}`. That's true of adjoints of matrices of matrices in general, so is a limitation of the `AnyAbstractSparseArray` union type, which is based on the [`Adapt.WrappedArray`](https://github.com/JuliaGPU/Adapt.jl/blob/v4.3.0/src/wrappers.jl#L72-L109) wrapper union.
2. `AnyAbstractSparseArray` is used to catch objects that act as sparse arrays to give them a sparse array memory layout and interface, so they get forwarded to sparse implementations of matrix multiplication. Because of 1., that wasn't happening for adjoints of sparse matrices of matrices, which is the case for `blocks(A')`.

This is a hacky solution to catch a few cases that are missed by the current design, but ideally we would have a more systematic fix. One would be to make `AnyAbstractSparseArray` more general so that it doesn't have that type constraint between the wrapper element type and parent element type, since that's probably an issue for other wrapper types as well. Refactors like https://github.com/ITensor/DerivableInterfaces.jl/pull/28 and #39 would also help make it easier to catch and fix this kind of issue since it was a bit tough to hunt down, since some of these definitions are implicitly derived using `DerivableInterfaces.jl`.