### PR TITLE
Reformat Project.toml (ordering only)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,10 @@
 name = "SparseArraysBase"
 uuid = "0d5efcca-f356-4864-8770-e1ed8d78f208"
-authors = ["ITensor developers <support@itensor.org> and contributors"]
 version = "0.9.1"
+authors = ["ITensor developers <support@itensor.org> and contributors"]
+
+[workspace]
+projects = ["benchmark", "dev", "docs", "examples", "test"]
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
@@ -41,6 +44,3 @@ SparseArrays = "1.10"
 TensorAlgebra = "0.6.2, 0.7"
 TypeParameterAccessors = "0.4.3"
 julia = "1.10"
-
-[workspace]
-projects = ["benchmark", "dev", "docs", "examples", "test"]


### PR DESCRIPTION
Reorders top-level keys and sections in Project.toml.
No semantic changes.