### PR TITLE
Add gates in test workflows

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -29,3 +29,13 @@ jobs:
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
       pkg: "${{ matrix.pkg }}"
+  integration-gate:
+    name: IntegrationTest
+    needs: integration-test
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any downstream integration test failed
+        run: |
+          echo "integration-test.result = ${{ needs['integration-test'].result }}"
+          test "${{ needs['integration-test'].result }}" = "success"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -40,3 +40,13 @@ jobs:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
     secrets:
       CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
+  tests-gate:
+    name: Tests
+    needs: tests
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any matrix leg failed
+        run: |
+          echo "tests.result = ${{ needs.tests.result }}"
+          test "${{ needs.tests.result }}" = "success"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SparseArraysBase"
 uuid = "0d5efcca-f356-4864-8770-e1ed8d78f208"
-version = "0.9.8"
+version = "0.9.9"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]


### PR DESCRIPTION
Adds a final "gate" on the test workflows that pass or fail based on the overall results of the testing matrix. That is helpful for having a single point of detecting the overall status of tests, for example for branch protection rules.