### PR TITLE
Test hardened ITensorActions workflows

### DIFF
--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,16 +1,14 @@
 name: "Format Check"
 on:
-  pull_request_target:
+  pull_request:
     types:
       - "opened"
       - "synchronize"
       - "reopened"
       - "ready_for_review"
-permissions:
-  contents: "read"
-  actions: "write"
-  pull-requests: "write"
 jobs:
   format-check:
     name: "Format Check"
-    uses: "ITensor/ITensorActions/.github/workflows/FormatCheck.yml@main"
+    uses: "ITensor/ITensorActions/.github/workflows/FormatCheck.yml@dc36f8c88cd2858bdfa5e2458d108027d6b72807"
+    with:
+      concurrent-jobs: true

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -9,6 +9,4 @@ on:
 jobs:
   format-check:
     name: "Format Check"
-    uses: "ITensor/ITensorActions/.github/workflows/FormatCheck.yml@dc36f8c88cd2858bdfa5e2458d108027d6b72807"
-    with:
-      concurrent-jobs: true
+    uses: "ITensor/ITensorActions/.github/workflows/FormatCheck.yml@v1"

--- a/.github/workflows/FormatCheckComment.yml
+++ b/.github/workflows/FormatCheckComment.yml
@@ -1,0 +1,16 @@
+name: "Format Check Comment"
+on:
+  workflow_run:
+    workflows:
+      - "Format Check"
+    types:
+      - "completed"
+jobs:
+  comment:
+    name: "Format Check Comment"
+    if: "github.event.workflow_run.event == 'pull_request'"
+    permissions:
+      pull-requests: "write"
+      actions: "read"
+    uses: "ITensor/ITensorActions/.github/workflows/FormatCheckComment.yml@dc36f8c88cd2858bdfa5e2458d108027d6b72807"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheckComment.yml
+++ b/.github/workflows/FormatCheckComment.yml
@@ -12,5 +12,5 @@ jobs:
     permissions:
       pull-requests: "write"
       actions: "read"
-    uses: "ITensor/ITensorActions/.github/workflows/FormatCheckComment.yml@dc36f8c88cd2858bdfa5e2458d108027d6b72807"
+    uses: "ITensor/ITensorActions/.github/workflows/FormatCheckComment.yml@v1"
     secrets: "inherit"

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - "main"
     tags: "*"
-  pull_request_target:
+  pull_request:
     types:
       - "opened"
       - "synchronize"
@@ -14,27 +14,14 @@ on:
 jobs:
   integration-test:
     name: "IntegrationTest"
-    strategy:
-      fail-fast: false
-      matrix:
-        pkg:
-          - "BlockSparseArrays"
-          - "DiagonalArrays"
-          - "FusionTensors"
-          - "GradedArrays"
-    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@main"
+    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@dc36f8c88cd2858bdfa5e2458d108027d6b72807"
     secrets: "inherit"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
-      pkg: "${{ matrix.pkg }}"
-  integration-gate:
-    name: "IntegrationTest"
-    needs: "integration-test"
-    if: "${{ always() && needs.integration-test.result != 'skipped' }}"
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: "Fail if any downstream integration test failed"
-        run: |
-          echo "integration-test.result = ${{ needs.integration-test.result }}"
-          test "${{ needs.integration-test.result }}" = "success"
-          
+      pkgs: |
+        [
+          "BlockSparseArrays",
+          "DiagonalArrays",
+          "FusionTensors",
+          "GradedArrays"
+        ]

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   integration-test:
     name: "IntegrationTest"
-    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@dc36f8c88cd2858bdfa5e2458d108027d6b72807"
+    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@v1"
     secrets: "inherit"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"

--- a/.github/workflows/IntegrationTestRequest.yml
+++ b/.github/workflows/IntegrationTestRequest.yml
@@ -11,6 +11,6 @@ jobs:
     permissions:
       checks: "write"
       pull-requests: "write"
-    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTestRequest.yml@dc36f8c88cd2858bdfa5e2458d108027d6b72807"
+    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTestRequest.yml@v1"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"

--- a/.github/workflows/IntegrationTestRequest.yml
+++ b/.github/workflows/IntegrationTestRequest.yml
@@ -8,7 +8,9 @@ jobs:
     if: |
       github.event.issue.pull_request &&
       contains(fromJSON('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)
-      
-    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTestRequest.yml@main"
+    permissions:
+      checks: "write"
+      pull-requests: "write"
+    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTestRequest.yml@dc36f8c88cd2858bdfa5e2458d108027d6b72807"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"


### PR DESCRIPTION
## Summary

This PR is a workflow canary for the hardened reusable workflows in ITensorActions PR #88.

It updates the SparseArraysBase workflow callers to point at the ITensorActions PR head SHA so we can validate the new behavior before doing a broader ecosystem sweep:

- switch `IntegrationTest.yml` from `pull_request_target` to `pull_request`
- use the new `IntegrationTest` `pkgs` JSON-array input, keeping one package per line for readable YAML diffs
- switch `FormatCheck.yml` from `pull_request_target` to `pull_request`
- add `FormatCheckComment.yml` for the trusted comment-writing step
- point `/integrationtest` at the same ITensorActions test SHA and grant the check-writing permissions it needs

## Canary Note

`FormatCheck.yml` sets `concurrent-jobs: true` only for this canary. The old default-branch `pull_request_target` Format Check still exists while this PR is open, and otherwise cancels the new `pull_request` run through the shared concurrency group. This line is not necessarily part of the eventual ecosystem sweep.

## Validation Goal

This PR should validate the public-package IntegrationTest matrix and the read-only FormatCheck parse phase on a normal same-repo PR. The `workflow_run`-based comment workflow is included here, but full comment-writing validation may require a follow-up PR after this workflow exists on the default branch.

## Test Plan

- Let GitHub Actions run on this PR.
- Confirm the aggregate `IntegrationTest` check passes for the public downstream matrix.
- Confirm `Format Check / Check Formatting` runs from `pull_request` without trusted write permissions.
