### PR TITLE
Switch remaining ITensorActions workflow refs to v1

### DIFF
--- a/.github/workflows/CheckCompatBounds.yml
+++ b/.github/workflows/CheckCompatBounds.yml
@@ -4,6 +4,6 @@ on:
 jobs:
   check-compat-bounds:
     name: "Check Compat Bounds"
-    uses: "ITensor/ITensorActions/.github/workflows/CheckCompatBounds.yml@main"
+    uses: "ITensor/ITensorActions/.github/workflows/CheckCompatBounds.yml@v1"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   compat-helper:
     name: "CompatHelper"
-    uses: "ITensor/ITensorActions/.github/workflows/CompatHelper.yml@main"
+    uses: "ITensor/ITensorActions/.github/workflows/CompatHelper.yml@v1"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
     secrets: "inherit"

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   build-and-deploy-docs:
     name: "Documentation"
-    uses: "ITensor/ITensorActions/.github/workflows/Documentation.yml@main"
+    uses: "ITensor/ITensorActions/.github/workflows/Documentation.yml@v1"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
     secrets:

--- a/.github/workflows/FormatPullRequest.yml
+++ b/.github/workflows/FormatPullRequest.yml
@@ -12,5 +12,5 @@ permissions:
 jobs:
   format-pull-request:
     name: "Format Pull Request"
-    uses: "ITensor/ITensorActions/.github/workflows/FormatPullRequest.yml@main"
+    uses: "ITensor/ITensorActions/.github/workflows/FormatPullRequest.yml@v1"
     secrets: "inherit"

--- a/.github/workflows/Registrator.yml
+++ b/.github/workflows/Registrator.yml
@@ -16,7 +16,7 @@ permissions:
   issues: "write"
 jobs:
   Register:
-    uses: "ITensor/ITensorActions/.github/workflows/Registrator.yml@main"
+    uses: "ITensor/ITensorActions/.github/workflows/Registrator.yml@v1"
     with:
       localregistry: "ITensor/ITensorRegistry"
     secrets: "inherit"

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -9,5 +9,5 @@ env:
 jobs:
   TagBot:
     if: "github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'"
-    uses: "ITensor/ITensorActions/.github/workflows/TagBot.yml@main"
+    uses: "ITensor/ITensorActions/.github/workflows/TagBot.yml@v1"
     secrets: "inherit"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -32,7 +32,7 @@ jobs:
           - "ubuntu-latest"
           - "macOS-latest"
           - "windows-latest"
-    uses: "ITensor/ITensorActions/.github/workflows/Tests.yml@main"
+    uses: "ITensor/ITensorActions/.github/workflows/Tests.yml@v1"
     with:
       group: "${{ matrix.group }}"
       julia-version: "${{ matrix.version }}"

--- a/.github/workflows/VersionCheck.yml
+++ b/.github/workflows/VersionCheck.yml
@@ -4,6 +4,6 @@ on:
 jobs:
   version-check:
     name: "Version Check"
-    uses: "ITensor/ITensorActions/.github/workflows/VersionCheck.yml@main"
+    uses: "ITensor/ITensorActions/.github/workflows/VersionCheck.yml@v1"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SparseArraysBase"
 uuid = "0d5efcca-f356-4864-8770-e1ed8d78f208"
-version = "0.9.23"
+version = "0.9.24"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SparseArraysBase"
 uuid = "0d5efcca-f356-4864-8770-e1ed8d78f208"
-version = "0.9.24"
+version = "0.9.23"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]


### PR DESCRIPTION
Updates the remaining reusable workflow callers from ITensorActions@main to ITensorActions@v1.

This PR now covers:
- Tests.yml
- Documentation.yml
- VersionCheck.yml
- CheckCompatBounds.yml
- CompatHelper.yml
- FormatPullRequest.yml
- Registrator.yml
- TagBot.yml

The temporary package version bump was reverted so this is a workflow-only update.
