### PR TITLE
Add explicit permissions blocks to caller workflow files

### DIFF
--- a/.github/workflows/CheckCompatBounds.yml
+++ b/.github/workflows/CheckCompatBounds.yml
@@ -1,6 +1,8 @@
 name: "Check Compat Bounds"
 on:
   pull_request: ~
+permissions:
+  contents: "read"
 jobs:
   check-compat-bounds:
     name: "Check Compat Bounds"

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -11,12 +11,10 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: "${{ github.ref_name != github.event.repository.default_branch || github.ref != 'refs/tags/v*' }}"
 permissions:
-  contents: read
+  contents: "write"
 jobs:
   build-and-deploy-docs:
     name: "Documentation"
-    permissions:
-      contents: write
     uses: "ITensor/ITensorActions/.github/workflows/Documentation.yml@v1"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -10,9 +10,13 @@ on:
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: "${{ github.ref_name != github.event.repository.default_branch || github.ref != 'refs/tags/v*' }}"
+permissions:
+  contents: read
 jobs:
   build-and-deploy-docs:
     name: "Documentation"
+    permissions:
+      contents: write
     uses: "ITensor/ITensorActions/.github/workflows/Documentation.yml@v1"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -6,6 +6,8 @@ on:
       - "synchronize"
       - "reopened"
       - "ready_for_review"
+permissions:
+  contents: "read"
 jobs:
   format-check:
     name: "Format Check"

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -12,13 +12,11 @@ on:
       - "ready_for_review"
       - "converted_to_draft"
 permissions:
-  contents: read
+  actions: "read"
+  contents: "read"
 jobs:
   integration-test:
     name: "IntegrationTest"
-    permissions:
-      actions: read
-      contents: read
     uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@v1"
     secrets: "inherit"
     with:

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -11,9 +11,14 @@ on:
       - "reopened"
       - "ready_for_review"
       - "converted_to_draft"
+permissions:
+  contents: read
 jobs:
   integration-test:
     name: "IntegrationTest"
+    permissions:
+      actions: read
+      contents: read
     uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@v1"
     secrets: "inherit"
     with:

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -6,6 +6,9 @@ on:
   workflow_dispatch: ~
 env:
   REGISTRY_TAGBOT_ACTION: "JuliaRegistries/TagBot"
+permissions:
+  contents: "write"
+  issues: "read"
 jobs:
   TagBot:
     if: "github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -19,6 +19,8 @@ on:
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: "${{ startsWith(github.ref, 'refs/pull/') }}"
+permissions:
+  contents: "read"
 jobs:
   tests:
     name: "Tests"

--- a/.github/workflows/VersionCheck.yml
+++ b/.github/workflows/VersionCheck.yml
@@ -1,9 +1,14 @@
 name: "Version Check"
 on:
   pull_request: ~
+permissions:
+  contents: read
 jobs:
   version-check:
     name: "Version Check"
+    permissions:
+      contents: read
+      pull-requests: read
     uses: "ITensor/ITensorActions/.github/workflows/VersionCheck.yml@v1"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"

--- a/.github/workflows/VersionCheck.yml
+++ b/.github/workflows/VersionCheck.yml
@@ -2,13 +2,11 @@ name: "Version Check"
 on:
   pull_request: ~
 permissions:
-  contents: read
+  contents: "read"
+  pull-requests: "read"
 jobs:
   version-check:
     name: "Version Check"
-    permissions:
-      contents: read
-      pull-requests: read
     uses: "ITensor/ITensorActions/.github/workflows/VersionCheck.yml@v1"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-# Permissions-hardening canary marker — remove before merging.
 *.cov
 *.mem
 *.o

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Permissions-hardening canary marker — remove before merging.
 *.cov
 *.mem
 *.o


### PR DESCRIPTION
## Summary

Adds explicit `permissions:` blocks to the workflow files that call ITensorActions reusable workflows.

Most of these files previously declared no `permissions:` block and inherited their `GITHUB_TOKEN` ceiling from the repository / organization Actions defaults. After this change, each workflow's permissions live in the YAML rather than in a settings page, and any future change to the org or per-repo Actions default can only narrow (never widen) what these workflows can do.

Each block declares the minimum the workflow actually needs (`contents: read` for checkout-only workflows; elevated for Documentation gh-pages deploy, TagBot tag creation, IntegrationTest's gate job, and VersionCheck's PR-file lookup).

Verified by temporarily flipping this repo's per-repo Actions setting to `default_workflow_permissions: read` and `can_approve_pull_request_reviews: false` — the planned org-default end state. All workflows pass.