### PR TITLE
Verify v2 ruleset on a no-op change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ benchmark/*.json
 dev/
 docs/build/
 docs/src/index.md
+
+# (intentional newline for CI verification under v2 ruleset)


### PR DESCRIPTION
Trivial no-op .gitignore tweak to exercise PR-event workflows under the new ITensorActions v2 caller-side renames + matching ruleset contexts. Will be closed once CI confirms the new context strings match the new ruleset's required-status-checks.