### PR TITLE
[TEST — DO NOT MERGE] Pin ITensorActions reusables to the mf/subdir-inputs branch

### DIFF
--- a/.github/workflows/CheckCompatBounds.yml
+++ b/.github/workflows/CheckCompatBounds.yml
@@ -6,6 +6,6 @@ permissions:
 jobs:
   check-compat-bounds:
     name: "CheckCompatBounds"
-    uses: "ITensor/ITensorActions/.github/workflows/CheckCompatBounds.yml@v2"
+    uses: "ITensor/ITensorActions/.github/workflows/CheckCompatBounds.yml@mf/subdir-inputs"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   compathelper:
     name: "CompatHelper"
-    uses: "ITensor/ITensorActions/.github/workflows/CompatHelper.yml@v2"
+    uses: "ITensor/ITensorActions/.github/workflows/CompatHelper.yml@mf/subdir-inputs"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
     secrets: "inherit"

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   documentation:
     name: "Documentation"
-    uses: "ITensor/ITensorActions/.github/workflows/Documentation.yml@v2"
+    uses: "ITensor/ITensorActions/.github/workflows/Documentation.yml@mf/subdir-inputs"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
     secrets:

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   integration-test:
     name: "IntegrationTest"
-    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@v2"
+    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@mf/subdir-inputs"
     secrets: "inherit"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"

--- a/.github/workflows/Registrator.yml
+++ b/.github/workflows/Registrator.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   registrator:
     name: "Registrator"
-    uses: "ITensor/ITensorActions/.github/workflows/Registrator.yml@v2"
+    uses: "ITensor/ITensorActions/.github/workflows/Registrator.yml@mf/subdir-inputs"
     with:
       localregistry: "ITensor/ITensorRegistry"
     secrets: "inherit"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -34,7 +34,7 @@ jobs:
           - "ubuntu-latest"
           - "macOS-latest"
           - "windows-latest"
-    uses: "ITensor/ITensorActions/.github/workflows/Tests.yml@v2"
+    uses: "ITensor/ITensorActions/.github/workflows/Tests.yml@mf/subdir-inputs"
     with:
       group: "${{ matrix.group }}"
       julia-version: "${{ matrix.version }}"

--- a/.github/workflows/VersionCheck.yml
+++ b/.github/workflows/VersionCheck.yml
@@ -7,6 +7,6 @@ permissions:
 jobs:
   version-check:
     name: "VersionCheck"
-    uses: "ITensor/ITensorActions/.github/workflows/VersionCheck.yml@v2"
+    uses: "ITensor/ITensorActions/.github/workflows/VersionCheck.yml@mf/subdir-inputs"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SparseArraysBase"
 uuid = "0d5efcca-f356-4864-8770-e1ed8d78f208"
-version = "0.9.23"
+version = "0.9.24"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SparseArraysBase"
 uuid = "0d5efcca-f356-4864-8770-e1ed8d78f208"
-version = "0.9.24"
+version = "0.9.23"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]


### PR DESCRIPTION
## Summary
Smoke test for [ITensorActions#107](https://github.com/ITensor/ITensorActions/pull/107). Pins the six reusables that PR changes (or could affect) to its branch ref so SparseArraysBase's CI exercises them with default inputs.

Goal: confirm the new inputs (`subdirs` / `extra-dev-paths` / `test-args` / `subdir`) are purely additive — existing single-package consumers must see no behavior change.

Files pinned:
- `CompatHelper.yml` (new `subdirs` input)
- `Documentation.yml` (new `extra-dev-paths` input)
- `Tests.yml` (new `test-args` + `extra-dev-paths` inputs)
- `Registrator.yml` (new `subdir` input)
- `VersionCheck.yml` (new `subdirs` input + per-project classification rewrite)
- `CheckCompatBounds.yml` (no input change but pinned for completeness)

## Not for merge

This PR is for observation only. After CI clears (or fails informatively), it'll be closed and the pins reverted.